### PR TITLE
Add github action: publish to pypi

### DIFF
--- a/.github/workflows/python_package_publish.yml
+++ b/.github/workflows/python_package_publish.yml
@@ -1,0 +1,21 @@
+# This workflow will build Pyctuator, and publish it to pypi.org
+
+name: publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  run_image:
+    runs-on: [ubuntu-18.04]
+    container:
+      image: matanrubin/python-poetry:3.7
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: cd ..
+      - run: make bootstrap
+      - run: poetry update -vvv
+      - run: poetry build -vvv
+      - run: poetry publish --username __token__ --password ${{ secrets.PYPI_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test:
 	poetry run pytest --log-cli-level=4 --tb=no -v tests
 
 coverage:
-	poetry run pytest --cov-report xml:./cov.xml --cov-report html --cov-report term --cov=pyctuator --log-cli-level=4 --tb=no -v tests
+	poetry run pytest --cov-report xml:./coverage.xml --cov-report html --cov-report term --cov=pyctuator --log-cli-level=4 --tb=no -v tests
 
 pylint:
 	poetry run pylint --exit-zero pyctuator tests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-![build](https://github.com/SolarEdgeTech/pyctuator/workflows/build/badge.svg)
-![codecov](https://codecov.io/gh/SolarEdgeTech/pyctuator/branch/master/graph/badge.svg)
+[![PyPI](https://img.shields.io/pypi/v/pyctuator?color=green&style=plastic)](https://pypi.org/project/pyctuator/)
+[![build](https://github.com/SolarEdgeTech/pyctuator/workflows/build/badge.svg)](https://github.com/SolarEdgeTech/pyctuator/)
+[![Codecov](https://img.shields.io/codecov/c/github/SolarEdgeTech/pyctuator?style=plastic)](https://codecov.io/gh/SolarEdgeTech/pyctuator)
 
 # Pyctuator
 


### PR DESCRIPTION
New action uses a dedicated docker container with Poetry.
It builds the package and pushes it to pypi.org.
Add version badge to README.md (+switched coverage badge to shields.io)