### PR TITLE
Initialize logging before Pyctuator

### DIFF
--- a/examples/Advanced/advanced_example_app.py
+++ b/examples/Advanced/advanced_example_app.py
@@ -67,7 +67,6 @@ def get_conf(key: str) -> Any:
 # A FastAPI application is initialized providing some test API
 # ----------------------------------------------------------------------------------------------------------------------
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("ExampleApp")
 
 # Initialize a connection to the DB which the app is using

--- a/examples/FastAPI/fastapi_example_app.py
+++ b/examples/FastAPI/fastapi_example_app.py
@@ -8,7 +8,6 @@ from uvicorn.config import Config
 
 from pyctuator.pyctuator import Pyctuator
 
-logging.basicConfig(level=logging.INFO)
 my_logger = logging.getLogger("example")
 
 app = FastAPI(

--- a/examples/Flask/flask_example_app.py
+++ b/examples/Flask/flask_example_app.py
@@ -6,8 +6,6 @@ from flask import Flask
 
 from pyctuator.pyctuator import Pyctuator
 
-logging.basicConfig(level=logging.INFO)
-
 # Keep the console clear - configure werkzeug (flask's WSGI web app) not to log the detail of every incoming request
 logging.getLogger("werkzeug").setLevel(logging.WARNING)
 

--- a/examples/aiohttp/aiohttp_example_app.py
+++ b/examples/aiohttp/aiohttp_example_app.py
@@ -6,7 +6,6 @@ from aiohttp import web
 
 from pyctuator.pyctuator import Pyctuator
 
-logging.basicConfig(level=logging.INFO)
 my_logger = logging.getLogger("example")
 app = web.Application()
 routes = web.RouteTableDef()

--- a/pyctuator/pyctuator.py
+++ b/pyctuator/pyctuator.py
@@ -89,6 +89,11 @@ class Pyctuator:
         self.boot_admin_registration_handler: Optional[BootAdminRegistrationHandler] = None
 
         root_logger = logging.getLogger()
+        # If application did not initiate logging module, add default handler to root logger
+        # logging.info implicitly calls logging.basicConfig(), see logging.basicConfig in Python's documentation.
+        if not root_logger.hasHandlers():
+            logging.info("Logging not configured, using logging.basicConfig()")
+
         root_logger.addHandler(self.pyctuator_impl.logfile.log_messages)
 
         # Find and initialize an integration layer between the web-framework adn pyctuator


### PR DESCRIPTION
This allows calls to `logging.<log_level>` to be printed in console, even after Pyctuator's initialization