### PR TITLE
Enabling customization of application metadata

### DIFF
--- a/pyctuator/impl/spring_boot_admin_registration.py
+++ b/pyctuator/impl/spring_boot_admin_registration.py
@@ -25,7 +25,7 @@ class BootAdminRegistrationHandler:
             start_time: datetime,
             service_url: str,
             registration_interval_sec: int,
-            application_metadata: dict
+            application_metadata: Optional[dict] = None
     ) -> None:
         self.registration_url = registration_url
         self.registration_auth = registration_auth
@@ -35,7 +35,7 @@ class BootAdminRegistrationHandler:
         self.service_url = service_url if service_url.endswith("/") else service_url + "/"
         self.registration_interval_sec = registration_interval_sec
         self.instance_id = None
-        self.application_metadata = application_metadata
+        self.application_metadata = application_metadata if application_metadata else {}
 
         self.should_continue_registration_schedule: bool = False
         self.disable_certificate_validation_for_https_registration: bool = \

--- a/pyctuator/impl/spring_boot_admin_registration.py
+++ b/pyctuator/impl/spring_boot_admin_registration.py
@@ -25,6 +25,7 @@ class BootAdminRegistrationHandler:
             start_time: datetime,
             service_url: str,
             registration_interval_sec: int,
+            application_metadata: dict
     ) -> None:
         self.registration_url = registration_url
         self.registration_auth = registration_auth
@@ -34,6 +35,7 @@ class BootAdminRegistrationHandler:
         self.service_url = service_url if service_url.endswith("/") else service_url + "/"
         self.registration_interval_sec = registration_interval_sec
         self.instance_id = None
+        self.application_metadata = application_metadata
 
         self.should_continue_registration_schedule: bool = False
         self.disable_certificate_validation_for_https_registration: bool = \
@@ -58,7 +60,10 @@ class BootAdminRegistrationHandler:
             "managementUrl": self.pyctuator_base_url,
             "healthUrl": f"{self.pyctuator_base_url}/health",
             "serviceUrl": self.service_url,
-            "metadata": {"startup": self.start_time.isoformat()}
+            "metadata": {
+                "startup": self.start_time.isoformat(),
+                **self.application_metadata
+            }
         }
 
         logging.debug("Trying to post registration data to %s: %s",

--- a/pyctuator/pyctuator.py
+++ b/pyctuator/pyctuator.py
@@ -38,6 +38,7 @@ class Pyctuator:
             logfile_max_size: int = 10000,
             logfile_formatter: str = default_logfile_format,
             auto_deregister: bool = True,
+            metadata: dict = None
     ) -> None:
         """The entry point for integrating pyctuator with a web-frameworks such as FastAPI and Flask.
 
@@ -120,6 +121,7 @@ class Pyctuator:
                             start_time,
                             app_url,
                             registration_interval_sec,
+                            metadata
                         )
 
                         # Deregister from SBA on exit

--- a/pyctuator/pyctuator.py
+++ b/pyctuator/pyctuator.py
@@ -38,7 +38,7 @@ class Pyctuator:
             logfile_max_size: int = 10000,
             logfile_formatter: str = default_logfile_format,
             auto_deregister: bool = True,
-            metadata: dict = None
+            metadata: Optional[dict] = {}
     ) -> None:
         """The entry point for integrating pyctuator with a web-frameworks such as FastAPI and Flask.
 
@@ -91,6 +91,8 @@ class Pyctuator:
 
         self.boot_admin_registration_handler: Optional[BootAdminRegistrationHandler] = None
 
+        self.metadata = metadata
+
         root_logger = logging.getLogger()
         # If application did not initiate logging module, add default handler to root logger
         # logging.info implicitly calls logging.basicConfig(), see logging.basicConfig in Python's documentation.
@@ -121,7 +123,7 @@ class Pyctuator:
                             start_time,
                             app_url,
                             registration_interval_sec,
-                            metadata
+                            self.metadata
                         )
 
                         # Deregister from SBA on exit

--- a/pyctuator/pyctuator.py
+++ b/pyctuator/pyctuator.py
@@ -38,7 +38,7 @@ class Pyctuator:
             logfile_max_size: int = 10000,
             logfile_formatter: str = default_logfile_format,
             auto_deregister: bool = True,
-            metadata: Optional[dict] = {}
+            metadata: Optional[dict] = None
     ) -> None:
         """The entry point for integrating pyctuator with a web-frameworks such as FastAPI and Flask.
 
@@ -70,6 +70,10 @@ class Pyctuator:
         :param registration_interval_sec: how often pyctuator will renew its registration with spring-boot-admin
         :param free_disk_space_down_threshold_bytes: amount of free space in bytes in "./" (the application's current
          working directory) below which the built-in disk-space health-indicator will fail
+        :param auto_deregister: if true, pyctuator will automatically deregister from SBA during shutdown, needed for
+        example when running in k8s so every time a new pod is created it is assigned a different IP address, resulting
+        with SBA showing "offline" instances
+        :param metadata: optional metadata key-value pairs that are displayed in SBA main page of an instance
         """
 
         self.auto_deregister = auto_deregister

--- a/tests/aiohttp_test_server.py
+++ b/tests/aiohttp_test_server.py
@@ -24,6 +24,7 @@ class AiohttpPyctuatorServer(PyctuatorServer):
             "http://localhost:8888/pyctuator",
             "http://localhost:8001/register",
             registration_interval_sec=1,
+            metadata=self.metadata,
         )
 
         @self.routes.get("/logfile_test_repeater")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import logging
+import random
 import secrets
 import threading
 import time
@@ -155,6 +156,7 @@ def endpoints(registration_tracker: RegistrationTrackerFixture) -> Endpoints:
 
 
 class PyctuatorServer(ABC):
+    metadata: Optional[dict] = {f"k{i}": f"v{i}" for i in range(random.randrange(10))}
 
     @abstractmethod
     def start(self) -> None:

--- a/tests/fast_api_test_server.py
+++ b/tests/fast_api_test_server.py
@@ -27,6 +27,7 @@ class FastApiPyctuatorServer(PyctuatorServer):
             "http://localhost:8000/pyctuator",
             "http://localhost:8001/register",
             registration_interval_sec=1,
+            metadata=self.metadata,
         )
 
         @self.app.get("/logfile_test_repeater", tags=["pyctuator"])

--- a/tests/flask_test_server.py
+++ b/tests/flask_test_server.py
@@ -20,7 +20,8 @@ class FlaskPyctuatorServer(PyctuatorServer):
             "http://localhost:5000",
             "http://localhost:5000/pyctuator",
             "http://localhost:8001/register",
-            registration_interval_sec=1
+            registration_interval_sec=1,
+            metadata=self.metadata,
         )
 
         @self.app.route("/shutdown", methods=["POST"])

--- a/tests/test_pyctuator_e2e.py
+++ b/tests/test_pyctuator_e2e.py
@@ -19,8 +19,6 @@ from tests.aiohttp_test_server import AiohttpPyctuatorServer
 from tests.conftest import Endpoints, PyctuatorServer, RegistrationRequest, RegistrationTrackerFixture
 from tests.fast_api_test_server import FastApiPyctuatorServer
 from tests.flask_test_server import FlaskPyctuatorServer
-
-
 # mypy: ignore_errors
 from tests.tornado_test_server import TornadoPyctuatorServer
 
@@ -197,6 +195,11 @@ def test_recurring_registration_and_deregistration(
     assert registration_tracker.start_time == registration_tracker.registration.metadata["startup"]
     registration_start_time = datetime.fromisoformat(registration_tracker.start_time)
     assert registration_start_time > registration_tracker.test_start_time - timedelta(seconds=10)
+
+    # Verify that the randomly generated metadata created when the server starter are included in the registration
+    metadata = registration_tracker.registration.metadata
+    metadata_without_startup = {k: metadata[k] for k in metadata if k != "startup"}
+    assert metadata_without_startup == pyctuator_server.metadata
 
     # Ask to deregister (in real life, called by atexit) and verify it was registered
     pyctuator_server.atexit()

--- a/tests/tornado_test_server.py
+++ b/tests/tornado_test_server.py
@@ -53,6 +53,7 @@ class TornadoPyctuatorServer(PyctuatorServer):
             registration_url=f"http://localhost:8001/register",
             app_description="Demonstrate Spring Boot Admin Integration with Tornado",
             registration_interval_sec=1,
+            metadata=self.metadata,
         )
 
         self.io_loop: Optional[ioloop.IOLoop] = None


### PR DESCRIPTION
Hello, first I would like to congratulate all the maintainers for this relevant project.

I am adopting the actuator in all the languages ​​we use (node, python, .netCore and Java).

I missed an option to define the application's metadata for spring boot registration.

I made this simple proposal to support customized metadata.

I hope that this PR is worthy to be adopted.

![image](https://user-images.githubusercontent.com/1657688/117384824-361dba00-aeba-11eb-85c4-1ddf23b85bf8.png)

![image](https://user-images.githubusercontent.com/1657688/117384905-5cdbf080-aeba-11eb-86ef-fd85cb071a3a.png)

![image](https://user-images.githubusercontent.com/1657688/117385338-4a15eb80-aebb-11eb-9ab0-baaa3b5617b5.png)


I found a block to run the tests locally, I am trying hard to beat it.

To guarantee functionality, I tested it manually, either passing the new parameter or omitting it.