### PR TITLE
Running SBA in container should setup host-gateway to enable it to co…

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ To run these examples, you'll need to have Spring Boot Admin running in a local 
 
 Unless the example includes a docker-compose file, you'll need to start Spring Boot Admin using docker directly:
 ```sh
-docker run --rm -p 8080:8080 michayaak/spring-boot-admin:2.2.3-1
+docker run --rm -p 8080:8080 --add-host=host.docker.internal:host-gateway michayaak/spring-boot-admin:2.2.3-1
 ```
 (the docker image's tag represents the version of Spring Boot Admin, so if you need to use version `2.0.0`, use `michayaak/spring-boot-admin:2.0.0` instead, note it accepts connections on port 8082).
 

--- a/examples/FastAPI/README.md
+++ b/examples/FastAPI/README.md
@@ -4,7 +4,7 @@ This example demonstrates the integration with the [FastAPI](https://fastapi.tia
 ## Running the example
 1. Start an instance of SBA (Spring Boot Admin):
     ```sh
-    docker run --rm -p 8080:8080 michayaak/spring-boot-admin:2.2.3-1
+    docker run --rm -p 8080:8080 --add-host=host.docker.internal:host-gateway michayaak/spring-boot-admin:2.2.3-1
     ```
 2. Once Spring Boot Admin is running, you can run the examples as follow:
     ```sh

--- a/examples/Flask/README.md
+++ b/examples/Flask/README.md
@@ -4,7 +4,7 @@ This example demonstrates the integration with the [Flask](https://flask.pallets
 ## Running the example
 1. Start an instance of SBA (Spring Boot Admin):
     ```sh
-    docker run --rm -p 8080:8080 michayaak/spring-boot-admin:2.2.3-1
+    docker run --rm -p 8080:8080 --add-host=host.docker.internal:host-gateway michayaak/spring-boot-admin:2.2.3-1
     ```
 2. Once Spring Boot Admin is running, you can run the examples as follow:
     ```sh

--- a/examples/aiohttp/README.md
+++ b/examples/aiohttp/README.md
@@ -4,7 +4,7 @@ This example demonstrates the integration with the [aiohttp](https://docs.aiohtt
 ## Running the example
 1. Start an instance of SBA (Spring Boot Admin):
     ```sh
-    docker run --rm -p 8080:8080 michayaak/spring-boot-admin:2.2.3-1
+    `docker run --rm -p 8080:8080 --add-host=host.docker.internal:host-gateway michayaak/spring-boot-admin:2.2.3-1`
     ```
 2. Once Spring Boot Admin is running, you can run the examples as follow:
     ```sh

--- a/examples/tornado/README.md
+++ b/examples/tornado/README.md
@@ -4,7 +4,7 @@ This example demonstrates the integration with the [Tornado](https://www.tornado
 ## Running the example
 1. Start an instance of SBA (Spring Boot Admin):
     ```sh
-    docker run --rm -p 8080:8080 michayaak/spring-boot-admin:2.2.3-1
+    docker run --rm -p 8080:8080 --add-host=host.docker.internal:host-gateway michayaak/spring-boot-admin:2.2.3-1
     ```
 2. Once Spring Boot Admin is running, you can run the examples as follow:
     ```sh


### PR DESCRIPTION
…nnect to example app

Examples updated to include docker settings that enable SBA in container to access example
app running on the host machine (outside of any container) via the host.docker.internal name.

See https://stackoverflow.com/a/43541732/2692895