### PR TITLE
Fix issue #110: updated flask json import

### DIFF
--- a/pyctuator/impl/flask_pyctuator.py
+++ b/pyctuator/impl/flask_pyctuator.py
@@ -6,7 +6,7 @@ from typing import Dict, Tuple, Any, Mapping, List
 
 from flask import Flask, Blueprint, request, jsonify, after_this_request
 from flask import Response, make_response
-from flask.json.provider import DefaultJSONProvider
+from flask.json import JSONProvider as DefaultJSONProvider
 # from flask.json import JSONEncoder
 from werkzeug.datastructures import Headers
 


### PR DESCRIPTION
I updated the flask json import so it now matches modern versions of flask. There were some changes made to flask so flask.json.provider and DefaultJSONProvider are no longer named like that.